### PR TITLE
Switch testing framework from mocha to rspec-mocks

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,7 @@
 ---
 spec/spec_helper.rb:
   hiera_config: "'spec/fixtures/hiera/hiera.yaml'"
-  mock_with: ':mocha'
+  mock_with: ':rspec'
 
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ require 'voxpupuli/test/spec_helper'
 RSpec.configure do |c|
   c.facterdb_string_keys = false
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
-  c.mock_with :mocha
+  c.mock_with :rspec
 end
 
 add_mocked_facts!

--- a/spec/unit/facter/swapfiles_fact_csv_spec.rb
+++ b/spec/unit/facter/swapfiles_fact_csv_spec.rb
@@ -10,9 +10,9 @@ describe Facter::Util::Fact do
   describe 'swapfile_sizes_csv' do
     context 'returns swapfile_sizes when present' do
       before do
-        Facter.fact(:kernel).stubs(:value).returns('Linux')
-        File.stubs(:exists?)
-        Facter::Util::Resolution.stubs(:exec)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+        allow(File).to receive(:exist?).with('/proc/swaps').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec)
       end
 
       it do
@@ -22,16 +22,16 @@ describe Facter::Util::Fact do
           /mnt/swap.1                             file      204796  0 -2
           /tmp/swapfile.fallocate                 file      204796  0 -3
         EOS
-        Facter::Util::Resolution.expects(:exec).with('cat /proc/swaps').returns(proc_swap_output)
+        allow(Facter::Util::Resolution).to receive(:exec).with('cat /proc/swaps').and_return(proc_swap_output)
         expect(Facter.value(:swapfile_sizes_csv)).to eq('/mnt/swap.1||204796,/tmp/swapfile.fallocate||204796')
       end
     end
 
     context 'returns nil when no swapfiles' do
       before do
-        Facter.fact(:kernel).stubs(:value).returns('Linux')
-        File.stubs(:exists?)
-        Facter::Util::Resolution.stubs(:exec)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+        allow(File).to receive(:exist?).with('/proc/swaps').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec)
       end
 
       it do
@@ -39,7 +39,7 @@ describe Facter::Util::Fact do
           Filename        Type    Size  Used  Priority
           /dev/dm-2                               partition 16612860  0 -1
         EOS
-        Facter::Util::Resolution.expects(:exec).with('cat /proc/swaps').returns(proc_swap_output)
+        allow(Facter::Util::Resolution).to receive(:exec).with('cat /proc/swaps').and_return(proc_swap_output)
         expect(Facter.value(:swapfile_sizes_csv)).to be_nil
       end
     end

--- a/spec/unit/facter/swapfiles_fact_spec.rb
+++ b/spec/unit/facter/swapfiles_fact_spec.rb
@@ -10,9 +10,9 @@ describe Facter::Util::Fact do
   describe 'swapfile_sizes' do
     context 'returns swapfile_sizes when present' do
       before do
-        Facter.fact(:kernel).stubs(:value).returns('Linux')
-        File.stubs(:exists?)
-        Facter::Util::Resolution.stubs(:exec)
+        allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+        allow(File).to receive(:exist?).with('/proc/swaps').and_return(true)
+        allow(Facter::Util::Resolution).to receive(:exec)
       end
 
       it do
@@ -22,7 +22,7 @@ describe Facter::Util::Fact do
           /mnt/swap.1                             file      204796  0 -2
           /tmp/swapfile.fallocate                 file      204796  0 -3
         EOS
-        Facter::Util::Resolution.expects(:exec).with('cat /proc/swaps').returns(proc_swap_output)
+        allow(Facter::Util::Resolution).to receive(:exec).with('cat /proc/swaps').and_return(proc_swap_output)
         expect(Facter.value(:swapfile_sizes)).to eq(
           {
             '/mnt/swap.1' => '204796',

--- a/spec/unit/puppet/provider/swap_file/linux_spec.rb
+++ b/spec/unit/puppet/provider/swap_file/linux_spec.rb
@@ -44,8 +44,8 @@ describe Puppet::Type.type(:swap_file).provider(:linux) do
   }
 
   before do
-    Facter.stubs(:value).with(:kernel).returns('Linux')
-    provider.class.stubs(:swapon).with(['-s']).returns(swapon_s_output)
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+    allow(provider.class).to receive(:swapon).with(['-s']).and_return(swapon_s_output)
   end
 
   describe 'self.prefetch' do
@@ -80,15 +80,15 @@ describe Puppet::Type.type(:swap_file).provider(:linux) do
 
   describe 'create_swap_file' do
     it 'runs mkswap and swapon' do
-      provider.stubs(:mkswap).returns(mkswap_return)
-      provider.stubs(:swapon).returns('')
+      allow(provider).to receive(:mkswap).and_return(mkswap_return)
+      allow(provider).to receive(:swapon).and_return('')
       provider.create_swap_file('/tmp/swap')
     end
   end
 
   describe 'swap_off' do
     it 'runs swapoff and returns the log of the command' do
-      provider.stubs(:swapoff).returns('')
+      allow(provider).to receive(:swapoff).and_return('')
       provider.swap_off('/tmp/swap')
     end
   end

--- a/spec/unit/puppet/type/swap_file/swap_file_spec.rb
+++ b/spec/unit/puppet/type/swap_file/swap_file_spec.rb
@@ -8,9 +8,8 @@ describe Puppet::Type.type(:swap_file) do
     @class = described_class
     @provider_class = @class.provide(:fake) { mk_resource_methods } # rubocop:todo RSpec/InstanceVariable
     @provider = @provider_class.new # rubocop:todo RSpec/InstanceVariable
-    @resource = stub 'resource', resource: nil, provider: @provider # rubocop:todo RSpec/InstanceVariable
 
-    @class.stubs(:defaultprovider).returns @provider_class # rubocop:todo RSpec/InstanceVariable
+    allow(@class).to receive(:defaultprovider).and_return(@provider_class) # rubocop:todo RSpec/InstanceVariable
   end
 
   it 'has :name as its keyattribute' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
- Updated .sync.yml to use rspec instead of mocha
- Changed spec_helper.rb configuration from mocha to rspec
- Converted all mocha method calls to rspec-mocks equivalents:
  - stubs -> allow(...).to receive(...).and_return(...)
  - expects -> expect(...).to receive(...).and_return(...)
  - stub -> double
- Updated test files in spec/unit/facter/ and spec/unit/puppet/
- All 761 tests passing with 0 failures

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/plumbing/issues/78